### PR TITLE
Use App ID for the gradle release app

### DIFF
--- a/.github/actions/update-github/action.yml
+++ b/.github/actions/update-github/action.yml
@@ -71,7 +71,7 @@ runs:
         GH_TOKEN=${{ steps.generate-github-app-token.outputs.token }}
         GITHUB_WORKFLOW_FILE=$GITHUB_WORKFLOW_FILE
         GITHUB_WORKFLOW_LINK=[GitHub UI]($GITHUB_WORKFLOW_URL)
-        GITHUB_WORKFLOW_RUN_LINK=[#${{ inputs.GITHUB_RUN_ID }}]($GITHUB_ACTIONS_PATH/runs/${{ inputs.GITHUB_RUN_ID }})
+        GITHUB_WORKFLOW_RUN_LINK=[#${{ github.run_number }}]($GITHUB_ACTIONS_PATH/runs/${{ inputs.GITHUB_RUN_ID }})
         EndOfFile
 
     - name: Clean-up temporary branch that was retaining the now-tagged release commit

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -25,8 +25,8 @@ on:
       GITHUB_APP_ID:
         description:
           "App ID for a GitHub App that is allowed to push directly to the default branch. Eg, App ID on:
-          https://github.com/organizations/guardian/settings/apps/gu-scala-library-release"
-        default: '807361' # Only for use by the Guardian!
+          https://github.com/organizations/guardian/settings/apps/gu-gradle-library-release"
+        default: '1576314' # Only for use by the Guardian!
         required: false # ...but if you're not the Guardian, you'll want to set this explicitly
         type: string
     secrets:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the default Github app ID used by the workflow to that of the [Gradle release app](https://github.com/apps/gu-gradle-library-release).

Depends on this PR: https://github.com/guardian/github-secret-access/pull/77

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
