### PR TITLE
Only commit changed API files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*       @guardian/android-admins
+*       @guardian/android-developers
 *       @rtyley

--- a/.github/actions/push-release-commit/action.yml
+++ b/.github/actions/push-release-commit/action.yml
@@ -32,15 +32,6 @@ inputs:
   GITHUB_REPO_URL:
     description: "GitHub repo URL"
     required: true
-  GITHUB_ACTOR:
-    description: "GitHub actor"
-    required: true
-  GITHUB_SERVER_URL:
-    description: "GitHub server URL"
-    required: true
-  GITHUB_RUN_ID:
-    description: "GitHub run ID"
-    required: true
 outputs:
   release-tag:
     description: "Release tag"
@@ -98,9 +89,9 @@ runs:
         RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
         VERSION_SUFFIX: ${{ inputs.VERSION_SUFFIX }}
         GITHUB_REPO_URL: ${{ inputs.GITHUB_REPO_URL }}
-        GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
-        GITHUB_SERVER_URL: ${{ inputs.GITHUB_SERVER_URL }}
-        GITHUB_RUN_ID: ${{ inputs.GITHUB_RUN_ID }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
       shell: bash
       run: |
         set -e

--- a/.github/actions/push-release-commit/action.yml
+++ b/.github/actions/push-release-commit/action.yml
@@ -7,6 +7,9 @@ inputs:
   GITHUB_APP_PRIVATE_KEY:
     description: "GitHub App private key"
     required: true
+  INCLUDE_API_FILES:
+    description: "Include API files in the release commit"
+    required: true
   SOURCE_DIR:
     description: "Path to source directory"
     required: false
@@ -40,9 +43,6 @@ inputs:
     required: true
   GITHUB_RUN_ID:
     description: "GitHub run ID"
-    required: true
-  INCLUDE_API_FILES:
-    description: "Include API files in the release commit"
     required: true
 outputs:
   release-tag:
@@ -156,7 +156,7 @@ runs:
         # in a json object for later use
         IFS=',' read -ra MOD_ARRAY <<< "$MODULES"
 
-        if [[ "${INCLUDE_API_FILES}" == "true" ]]; then
+        if [[ "${INCLUDE_API_FILES}" = "true" ]]; then
           for mod in "${MOD_ARRAY[@]}"; do
             MOD=$(echo "${mod}" | xargs)
             API_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r "$RELEASE_TAG" | grep "${MOD}/${API_FILE}")

--- a/.github/actions/push-release-commit/action.yml
+++ b/.github/actions/push-release-commit/action.yml
@@ -69,9 +69,7 @@ outputs:
   temporary-branch:
     description: "Temporary branch"
     value: ${{ steps.create-commit.outputs.temporary-branch }}
-  api-files:
-    description: "API files"
-    value: ${{ steps.create-commit.outputs.api-files }}
+
 runs:
   using: "composite"
   steps:
@@ -158,10 +156,6 @@ runs:
         # in a json object for later use
         IFS=',' read -ra MOD_ARRAY <<< "$MODULES"
 
-        API_FILES_JSON="["
-
-        # Remove trailing comma and close JSON array
-        API_FILES_JSON="${API_FILES_JSON%,}]"
         if [[ "${INCLUDE_API_FILES}" == "true" ]]; then
           for mod in "${MOD_ARRAY[@]}"; do
             MOD=$(echo "${mod}" | xargs)
@@ -210,5 +204,4 @@ runs:
         version-file-release-sha=$VERSION_FILE_RELEASE_SHA
         version-file-post-release-content=$VERSION_FILE_POST_RELEASE_CONTENT
         temporary-branch=$TEMPORARY_BRANCH
-        api-files=$API_FILES_JSON
         EndOfFile

--- a/.github/actions/push-release-commit/action.yml
+++ b/.github/actions/push-release-commit/action.yml
@@ -41,6 +41,9 @@ inputs:
   GITHUB_RUN_ID:
     description: "GitHub run ID"
     required: true
+  INCLUDE_API_FILES:
+    description: "Include API files in the release commit"
+    required: true
 outputs:
   release-tag:
     description: "Release tag"
@@ -157,27 +160,26 @@ runs:
 
         API_FILES_JSON="["
 
-        for mod in "${MOD_ARRAY[@]}"; do
-          MOD=$(echo "${mod}" | xargs)
-          API_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r "$RELEASE_TAG" | grep "${MOD}/${API_FILE}")
-          API_FILE_INITIAL_SHA=$(git rev-parse "$GITHUB_REF":"$API_FILE_PATH")
-          API_FILE_RELEASE_SHA=$(git rev-parse "$RELEASE_TAG":"$API_FILE_PATH")
-          API_FILE_RELEASE_CONTENT=$(git cat-file blob "$RELEASE_TAG":"$API_FILE_PATH" | base64 -w0)
-          API_FILE_POST_RELEASE_CONTENT=$(git cat-file blob unsigned/"$GITHUB_REF_NAME":"$API_FILE_PATH" | base64 -w0)
-
-          # Commit the API file changes for module
-          gh api --method PUT /repos/:owner/:repo/contents/"$API_FILE_PATH" \
-            --field branch="$TEMPORARY_BRANCH" \
-            --field message="Update public API file for module $MOD for $RELEASE_TAG" \
-            --field sha="$API_FILE_INITIAL_SHA" \
-            --field content="$API_FILE_RELEASE_CONTENT" --jq '.commit.sha'
-          
-
-          API_FILES_JSON="${API_FILES_JSON}{\"module\":\"$MOD\",\"api_file_path\":\"$API_FILE_PATH\",\"api_file_release_sha\":\"$API_FILE_RELEASE_SHA\",\"api_file_post_release_content\":\"$API_FILE_POST_RELEASE_CONTENT\"},"
-        done
-
         # Remove trailing comma and close JSON array
         API_FILES_JSON="${API_FILES_JSON%,}]"
+        if [[ "${INCLUDE_API_FILES}" == "true" ]]; then
+          for mod in "${MOD_ARRAY[@]}"; do
+            MOD=$(echo "${mod}" | xargs)
+            API_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r "$RELEASE_TAG" | grep "${MOD}/${API_FILE}")
+            API_FILE_INITIAL_SHA=$(git rev-parse "$GITHUB_REF":"$API_FILE_PATH")
+            API_FILE_RELEASE_SHA=$(git rev-parse "$RELEASE_TAG":"$API_FILE_PATH")
+            API_FILE_RELEASE_CONTENT=$(git cat-file blob "$RELEASE_TAG":"$API_FILE_PATH" | base64 -w0)
+            API_FILE_POST_RELEASE_CONTENT=$(git cat-file blob unsigned/"$GITHUB_REF_NAME":"$API_FILE_PATH" | base64 -w0)
+        
+            # Commit the API file changes for module
+            gh api --method PUT /repos/:owner/:repo/contents/"$API_FILE_PATH" \
+              --field branch="$TEMPORARY_BRANCH" \
+              --field message="Update public API file for module $MOD for $RELEASE_TAG" \
+              --field sha="$API_FILE_INITIAL_SHA" \
+              --field content="$API_FILE_RELEASE_CONTENT" --jq '.commit.sha'
+        
+          done
+        fi
 
         cat << EndOfFile > commit-message.txt
         $RELEASE_TAG published by $GITHUB_ACTOR

--- a/.github/actions/push-release-commit/action.yml
+++ b/.github/actions/push-release-commit/action.yml
@@ -7,9 +7,6 @@ inputs:
   GITHUB_APP_PRIVATE_KEY:
     description: "GitHub App private key"
     required: true
-  INCLUDE_API_FILES:
-    description: "Include API files in the release commit"
-    required: true
   SOURCE_DIR:
     description: "Path to source directory"
     required: false
@@ -22,8 +19,8 @@ inputs:
     description: "Path to API file"
     required: false
     default: "api/api.txt"
-  MODULES:
-    description: "Comma-separated list of modules"
+  API_UPDATED_MODULES:
+    description: "Comma-separated list of modules that need to be committed."
     required: true
   RELEASE_TYPE:
     description: "Release type"
@@ -97,7 +94,7 @@ runs:
         SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
         VERSION_FILE: ${{ inputs.VERSION_FILE }}
         API_FILE: ${{ inputs.API_FILE }}
-        MODULES: ${{ inputs.MODULES }}
+        API_UPDATED_MODULES: ${{ inputs.API_UPDATED_MODULES }}
         RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
         VERSION_SUFFIX: ${{ inputs.VERSION_SUFFIX }}
         GITHUB_REPO_URL: ${{ inputs.GITHUB_REPO_URL }}
@@ -152,12 +149,10 @@ runs:
         
         gh api --method POST /repos/:owner/:repo/git/refs -f ref="refs/heads/$TEMPORARY_BRANCH" -f sha="$GITHUB_SHA"
 
-        # Parse modules and iterate over them, committing API files and collecting their details
-        # in a json object for later use
-        IFS=',' read -ra MOD_ARRAY <<< "$MODULES"
-
-        if [[ "${INCLUDE_API_FILES}" = "true" ]]; then
-          for mod in "${MOD_ARRAY[@]}"; do
+        # Only commit API files for modules in API_UPDATED_MODULES
+        if [ -n "$API_UPDATED_MODULES" ]; then
+          IFS=',' read -ra UPDATED_MODS <<< "$API_UPDATED_MODULES"
+          for mod in "${UPDATED_MODS[@]}"; do
             MOD=$(echo "${mod}" | xargs)
             API_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r "$RELEASE_TAG" | grep "${MOD}/${API_FILE}")
             API_FILE_INITIAL_SHA=$(git rev-parse "$GITHUB_REF":"$API_FILE_PATH")
@@ -171,7 +166,6 @@ runs:
               --field message="Update public API file for module $MOD for $RELEASE_TAG" \
               --field sha="$API_FILE_INITIAL_SHA" \
               --field content="$API_FILE_RELEASE_CONTENT" --jq '.commit.sha'
-        
           done
         fi
 

--- a/.github/actions/update-github/action.yml
+++ b/.github/actions/update-github/action.yml
@@ -34,10 +34,6 @@ inputs:
   GITHUB_RUN_ID:
     description: "GitHub run ID"
     required: true
-  API_FILES:
-    description: "API files JSON"
-    required: false
-    default: ""
   VERSION_FILE_PATH:
     description: "Version file path"
     required: false
@@ -50,6 +46,7 @@ inputs:
     description: "Version file post release content"
     required: false
     default: ""
+
 runs:
   using: "composite"
   steps:
@@ -84,7 +81,6 @@ runs:
       env:
         RELEASE_TAG: ${{ inputs.RELEASE_TAG }}
         RELEASE_NOTES_URL: ${{ inputs.RELEASE_NOTES_URL }}
-        API_FILES: ${{ inputs.API_FILES }}
         VERSION_FILE_PATH: ${{ inputs.VERSION_FILE_PATH }}
         VERSION_FILE_RELEASE_SHA: ${{ inputs.VERSION_FILE_RELEASE_SHA }}
         VERSION_FILE_POST_RELEASE_CONTENT: ${{ inputs.VERSION_FILE_POST_RELEASE_CONTENT }}
@@ -93,31 +89,6 @@ runs:
       run: |
         gh release create $RELEASE_TAG --verify-tag --generate-notes --notes "Release run: $GITHUB_WORKFLOW_RUN_LINK"
         echo "GitHub Release notes: [$RELEASE_TAG]($RELEASE_NOTES_URL)" >> $GITHUB_STEP_SUMMARY
-
-        # The following is commented out in the original workflow:
-        # API_FILES_JSON="$API_FILES"
-        # echo "$API_FILES_JSON" | jq -c '.[]' | while read -r api_file; do
-        #   MOD=$(echo "$api_file" | jq -r '.module')
-        #   API_FILE_PATH=$(echo "$api_file" | jq -r '.api_file_path')
-        #   API_FILE_RELEASE_SHA=$(echo "$api_file" | jq -r '.api_file_release_sha')
-        #   API_FILE_POST_RELEASE_CONTENT=$(echo "$api_file" | jq -r '.api_file_post_release_content')
-        #   gh api --method PUT /repos/:owner/:repo/contents/$API_FILE_PATH \
-        #     --field message="Update public API file for $MOD for $RELEASE_TAG" \
-        #     --field sha="$API_FILE_RELEASE_SHA" \
-        #     --field content="$API_FILE_POST_RELEASE_CONTENT"
-        # done
-
-        # # Then commit the version file
-        # cat << EndOfFile > commit-message.txt
-        # Post-release of $RELEASE_TAG by @$GITHUB_ACTOR: set version
-        # 
-        # Setting snapshot version after @$GITHUB_ACTOR published $RELEASE_NOTES_URL
-        # EndOfFile
-        # 
-        # gh api --method PUT /repos/:owner/:repo/contents/$VERSION_FILE_PATH \
-        #   --field message="@commit-message.txt" \
-        #   --field sha="$VERSION_FILE_RELEASE_SHA" \
-        #   --field content="$VERSION_FILE_POST_RELEASE_CONTENT"
 
     - name: Update PR with comment
       if: ${{ inputs.RELEASE_TYPE == 'PREVIEW_FEATURE_BRANCH' }}

--- a/.github/actions/update-github/action.yml
+++ b/.github/actions/update-github/action.yml
@@ -25,15 +25,6 @@ inputs:
   GITHUB_REPO_URL:
     description: "GitHub repo URL"
     required: true
-  GITHUB_ACTOR:
-    description: "GitHub actor"
-    required: true
-  GITHUB_SERVER_URL:
-    description: "GitHub server URL"
-    required: true
-  GITHUB_RUN_ID:
-    description: "GitHub run ID"
-    required: true
   VERSION_FILE_PATH:
     description: "Version file path"
     required: false
@@ -68,7 +59,7 @@ runs:
         GH_TOKEN=${{ steps.generate-github-app-token.outputs.token }}
         GITHUB_WORKFLOW_FILE=$GITHUB_WORKFLOW_FILE
         GITHUB_WORKFLOW_LINK=[GitHub UI]($GITHUB_WORKFLOW_URL)
-        GITHUB_WORKFLOW_RUN_LINK=[#${{ github.run_number }}]($GITHUB_ACTIONS_PATH/runs/${{ inputs.GITHUB_RUN_ID }})
+        GITHUB_WORKFLOW_RUN_LINK=[#${{ github.run_number }}]($GITHUB_ACTIONS_PATH/runs/${{ github.run_id }})
         EndOfFile
 
     - name: Clean-up temporary branch that was retaining the now-tagged release commit
@@ -84,7 +75,7 @@ runs:
         VERSION_FILE_PATH: ${{ inputs.VERSION_FILE_PATH }}
         VERSION_FILE_RELEASE_SHA: ${{ inputs.VERSION_FILE_RELEASE_SHA }}
         VERSION_FILE_POST_RELEASE_CONTENT: ${{ inputs.VERSION_FILE_POST_RELEASE_CONTENT }}
-        GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
+        GITHUB_ACTOR: ${{ github.actor }}
       shell: bash
       run: |
         gh release create $RELEASE_TAG --verify-tag --generate-notes --notes "Release run: $GITHUB_WORKFLOW_RUN_LINK"
@@ -94,7 +85,7 @@ runs:
       if: ${{ inputs.RELEASE_TYPE == 'PREVIEW_FEATURE_BRANCH' }}
       env:
         RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
-        GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
+        GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
       shell: bash
       run: |

--- a/.github/actions/versioning/action.yml
+++ b/.github/actions/versioning/action.yml
@@ -182,8 +182,6 @@ runs:
         # Update version file with the new version
         echo "$MAJOR.$MINOR.$PATCH" > "$VERSION_FILE"
 
-        echo "Updated version to $MAJOR.$MINOR.$PATCH"
-
         # Commit the updated version
         git add "$VERSION_FILE"
         git commit -m "chore: update version to $MAJOR.$MINOR.$PATCH"
@@ -194,8 +192,6 @@ runs:
         # Output the comma-separated list of modules with non-patch bumps
         API_UPDATED_MODULES_CSV=$(IFS=, ; echo "${API_UPDATED_MODULES[*]}")
         
-        echo "API updated modules: $API_UPDATED_MODULES_CSV"
-
         cat << EndOfFile >> $GITHUB_OUTPUT
         api-updated-modules=$API_UPDATED_MODULES_CSV
         EndOfFile
@@ -219,7 +215,6 @@ runs:
         cat << EndOfFile >> $GITHUB_STEP_SUMMARY
         # Release $(git describe --tags --abbrev=0)
         Library built with Java ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}.
-        Include api files: ${{ steps.update_version_and_api_files.outputs.api-updated-modules }}
         EndOfFile
 
     - uses: actions/upload-artifact@v4

--- a/.github/actions/versioning/action.yml
+++ b/.github/actions/versioning/action.yml
@@ -26,6 +26,9 @@ outputs:
   library-build-major-java-version:
     description: "The major version of Java (eg '21', '17', or '11') the library should be built with"
     value: ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}
+  include-api-files:
+    description: "Whether to include API files in the release commit"
+    value: ${{ steps.update_version_and_api_files.outputs.include-api-files }}
 
 runs:
   using: "composite"
@@ -77,6 +80,7 @@ runs:
         gradle-version: wrapper
 
     - name: Update version and API files
+      id: update_version_and_api_files
       env:
         SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
         VERSION_FILE: ${{ inputs.VERSION_FILE }}
@@ -180,6 +184,13 @@ runs:
 
         # Add version_suffix to the version and tag the commit with the new version number
         git tag "v$MAJOR.$MINOR.$PATCH${VERSION_SUFFIX}"
+        
+        # Set include-api-files output to false if HIGHEST_BUMP is patch
+        if [ "$HIGHEST_BUMP" = "patch" ]; then
+          echo "include-api-files=false" >> $GITHUB_OUTPUT
+        else
+          echo "include-api-files=true" >> $GITHUB_OUTPUT
+        fi
 
     - name: Create bare repo with unsigned version update commits
       shell: bash

--- a/.github/actions/versioning/action.yml
+++ b/.github/actions/versioning/action.yml
@@ -26,9 +26,9 @@ outputs:
   library-build-major-java-version:
     description: "The major version of Java (eg '21', '17', or '11') the library should be built with"
     value: ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}
-  include-api-files:
-    description: "Whether to include API files in the release commit"
-    value: ${{ steps.update_version_and_api_files.outputs.include-api-files }}
+  api-updated-modules:
+    description: "Comma-separated list of modules that have non Patch bumps"
+    value: ${{ steps.update_version_and_api_files.outputs.api-updated-modules }}
 
 runs:
   using: "composite"
@@ -122,6 +122,7 @@ runs:
         IFS=',' read -ra MOD_ARRAY <<< "$MODULES"
 
         HIGHEST_BUMP="patch"
+        API_UPDATED_MODULES=()
 
         for mod in "${MOD_ARRAY[@]}"; do
           MOD=$(echo "${mod}" | xargs)
@@ -155,6 +156,11 @@ runs:
             HIGHEST_BUMP="minor"
           fi
 
+          # Collect modules with non-patch bumps
+          if [ "$BUMP" != "patch" ]; then
+            API_UPDATED_MODULES+=("$MOD")
+          fi
+
           # Add this module's API file to the commit
           git add "$MOD_API_FILE"
 
@@ -184,17 +190,14 @@ runs:
 
         # Add version_suffix to the version and tag the commit with the new version number
         git tag "v$MAJOR.$MINOR.$PATCH${VERSION_SUFFIX}"
-        
-        # Set include-api-files output to false if HIGHEST_BUMP is patch
-        if [ "$HIGHEST_BUMP" = "patch" ]; then
-          INCLUDE_API_FILES="false"
-        else
-          INCLUDE_API_FILES="true"
-        fi
 
-        # Set the output variable for the Java version
+        # Output the comma-separated list of modules with non-patch bumps
+        API_UPDATED_MODULES_CSV=$(IFS=, ; echo "${API_UPDATED_MODULES[*]}")
+        
+        echo "API updated modules: $API_UPDATED_MODULES_CSV"
+
         cat << EndOfFile >> $GITHUB_OUTPUT
-        include-api-files=$INCLUDE_API_FILES
+        api-updated-modules=$API_UPDATED_MODULES_CSV
         EndOfFile
 
     - name: Create bare repo with unsigned version update commits
@@ -216,7 +219,7 @@ runs:
         cat << EndOfFile >> $GITHUB_STEP_SUMMARY
         # Release $(git describe --tags --abbrev=0)
         Library built with Java ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}.
-        Include api files: ${{ steps.update_version_and_api_files.outputs.include-api-files }}
+        Include api files: ${{ steps.update_version_and_api_files.outputs.api-updated-modules }}
         EndOfFile
 
     - uses: actions/upload-artifact@v4

--- a/.github/actions/versioning/action.yml
+++ b/.github/actions/versioning/action.yml
@@ -187,10 +187,15 @@ runs:
         
         # Set include-api-files output to false if HIGHEST_BUMP is patch
         if [ "$HIGHEST_BUMP" = "patch" ]; then
-          echo "include-api-files=false" >> $GITHUB_OUTPUT
+          INCLUDE_API_FILES="false"
         else
-          echo "include-api-files=true" >> $GITHUB_OUTPUT
+          INCLUDE_API_FILES="true"
         fi
+
+        # Set the output variable for the Java version
+        cat << EndOfFile >> $GITHUB_OUTPUT
+        include-api-files=$INCLUDE_API_FILES
+        EndOfFile
 
     - name: Create bare repo with unsigned version update commits
       shell: bash
@@ -211,6 +216,7 @@ runs:
         cat << EndOfFile >> $GITHUB_STEP_SUMMARY
         # Release $(git describe --tags --abbrev=0)
         Library built with Java ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}.
+        Include api files: ${{ steps.update_version_and_api_files.outputs.include-api-files }}
         EndOfFile
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -102,7 +102,6 @@ jobs:
       version-file-release-sha: ${{ steps.push-release-commit.outputs.version-file-release-sha }}
       version-file-post-release-content: ${{ steps.push-release-commit.outputs.version-file-post-release-content }}
       temporary-branch: ${{ steps.push-release-commit.outputs.temporary-branch }}
-      api-files: ${{ steps.push-release-commit.outputs.api-files }}
     steps:
       - name: Push Release Commit
         id: push-release-commit
@@ -191,7 +190,6 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          API_FILES: ${{ needs.push-release-commit.outputs.api-files }}
           VERSION_FILE_PATH: ${{ needs.push-release-commit.outputs.version-file-path }}
           VERSION_FILE_RELEASE_SHA: ${{ needs.push-release-commit.outputs.version-file-release-sha }}
           VERSION_FILE_POST_RELEASE_CONTENT: ${{ needs.push-release-commit.outputs.version-file-post-release-content }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -120,6 +120,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          INCLUDE_API_FILES: ${{ needs.versioning.outputs.include-api-files }}
 
   create-artifacts:
     name: 🎊 Create artifacts

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - name: Versioning
         id: versioning
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/versioning@main
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/versioning@ab/only-commit-api-files-if-changed
         with:
           SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
           MODULES: ${{ inputs.MODULES }}
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Push Release Commit
         id: push-release-commit
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@main
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@ab/only-commit-api-files-if-changed
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
@@ -133,7 +133,7 @@ jobs:
     steps:
       - name: Create Artifacts
         id: create-artifacts
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/create-artifacts@main
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/create-artifacts@ab/only-commit-api-files-if-changed
         with:
           SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
           MODULES: ${{ inputs.MODULES }}
@@ -177,7 +177,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update GitHub
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/update-github@main
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/update-github@ab/only-commit-api-files-if-changed
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+          INCLUDE_API_FILES: ${{ needs.versioning.outputs.include-api-files }}
           SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
           VERSION_FILE: ${{ inputs.VERSION_FILE }}
           API_FILE: ${{ inputs.API_FILE }}
@@ -119,7 +120,6 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          INCLUDE_API_FILES: ${{ needs.versioning.outputs.include-api-files }}
 
   create-artifacts:
     name: 🎊 Create artifacts

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -109,11 +109,10 @@ jobs:
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-          INCLUDE_API_FILES: ${{ needs.versioning.outputs.include-api-files }}
           SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
           VERSION_FILE: ${{ inputs.VERSION_FILE }}
           API_FILE: ${{ inputs.API_FILE }}
-          MODULES: ${{ inputs.MODULES }}
+          API_UPDATED_MODULES: ${{ needs.versioning.outputs.api-updated-modules }}
           RELEASE_TYPE: ${{ needs.init.outputs.release-type }}
           VERSION_SUFFIX: ${{ needs.init.outputs.version-suffix }}
           GITHUB_REPO_URL: ${{ env.GITHUB_REPO_URL }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -116,9 +116,6 @@ jobs:
           RELEASE_TYPE: ${{ needs.init.outputs.release-type }}
           VERSION_SUFFIX: ${{ needs.init.outputs.version-suffix }}
           GITHUB_REPO_URL: ${{ env.GITHUB_REPO_URL }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
 
   create-artifacts:
     name: 🎊 Create artifacts
@@ -186,9 +183,6 @@ jobs:
           RELEASE_NOTES_URL: ${{ needs.push-release-commit.outputs.release-notes-url }}
           TEMPORARY_BRANCH: ${{ needs.push-release-commit.outputs.temporary-branch }}
           GITHUB_REPO_URL: ${{ env.GITHUB_REPO_URL }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
           VERSION_FILE_PATH: ${{ needs.push-release-commit.outputs.version-file-path }}
           VERSION_FILE_RELEASE_SHA: ${{ needs.push-release-commit.outputs.version-file-release-sha }}
           VERSION_FILE_POST_RELEASE_CONTENT: ${{ needs.push-release-commit.outputs.version-file-post-release-content }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - name: Versioning
         id: versioning
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/versioning@ab/only-commit-api-files-if-changed
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/versioning@main
         with:
           SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
           MODULES: ${{ inputs.MODULES }}
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Push Release Commit
         id: push-release-commit
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@ab/only-commit-api-files-if-changed
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@main
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Create Artifacts
         id: create-artifacts
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/create-artifacts@ab/only-commit-api-files-if-changed
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/create-artifacts@main
         with:
           SOURCE_DIR: ${{ inputs.SOURCE_DIR }}
           MODULES: ${{ inputs.MODULES }}
@@ -173,7 +173,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update GitHub
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/update-github@ab/only-commit-api-files-if-changed
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/update-github@main
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The primary change in this PR is to address a bug where there's a patch version update. 

In patch version updates, the API files don't change. The original implementation always attempted to commit API files. This causes a git error and workflow failure. See here for an example: https://github.com/guardian/source-apps/actions/runs/16216021092/job/45789365860#step:2:271. 

In this PR, I've changed to logic so we only commit changed API files. This also accounts for the scenario where multi-module repositories may only have updated API files in some modules.

Code changes:

1. Provided a new `api-updated-modules` output from `versioning` action. This is a comma separated list of modules where the API has changed.
2. Updated the `push-release-commig` action to only commit API files for modules in `api-updated-modules`

Other change: Removed some `GITHUB_` inputs to `push-release-commit` and `update-github`. Replaced with directly accessing `github.` properties. This makes these actions independently reusable if needed.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

[This PR on Source](https://github.com/guardian/source-apps/pull/219) uses this branch.

See the workflow run from that PR's branch here: https://github.com/guardian/source-apps/actions/runs/16223869474

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
