### PR TITLE
Give collective ownership in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*       @guardian/android-developers
-*       @rtyley
+*       @guardian/android-developers @rtyley


### PR DESCRIPTION
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

The old 2-line entries syntax here was wrong - effectively, I think we were saying that just @rtyley was the codeowner:

> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.

Here, `*` is the 'pattern' - denoting the entire repo. Because both lines have the same 'pattern', the first line is apparently ignored, and @rtyley is the only codeowner.

Hopefully this change - putting both owners on the same line - should mean that we have joint code-ownership, and my approval shouldn't be required to merge a PR here!
