### PR TITLE
[Health] Prevent `setup-gradle` from updating to beyond version 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: "gradle/actions/setup-gradle"
+        versions: [ ">=6.0.0" ]
+      - dependency-name: "gradle/actions"
+        versions: [ ">=6.0.0" ]


### PR DESCRIPTION
#### Description

#### What

Sets the max version for `setup-gradle` action to be v5 by preventing updates to v6 & above.

#### Why

See chat thread for more details: https://chat.google.com/room/AAAADLv-zSQ/uEWEF8xxk0Y/uEWEF8xxk0Y?cls=10

Gradle announced[1] some changes to the action:

1. They are moving the caching functionality to a separate closed source action. It will still be available as part of the main action for now. 
2. They are also changing the license on the cache action from MIT to their proprietary license. Updating to setup-gradle v6 will automatically mean accepting those license terms.
3. They are removing configuration caching support from the caching action

Their post (and messaging in some private chats) has indicated that they do not expect caching support to stay free forever except for open source repos. Their recommendation is to pay for Develocity and use their Universal Cache product[2].

[1]: https://blog.gradle.org/github-actions-for-gradle-v6
[2]: https://gradle.com/develocity/product/universal-cache/