### PR TITLE
Read updated API files from disk instead of a variable.

### DIFF
--- a/.github/actions/push-release-commit/action.yml
+++ b/.github/actions/push-release-commit/action.yml
@@ -148,7 +148,9 @@ runs:
             API_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r "$RELEASE_TAG" | grep "${MOD}/${API_FILE}")
             API_FILE_INITIAL_SHA=$(git rev-parse "$GITHUB_REF":"$API_FILE_PATH")
             API_FILE_RELEASE_SHA=$(git rev-parse "$RELEASE_TAG":"$API_FILE_PATH")
-            API_FILE_RELEASE_CONTENT=$(git cat-file blob "$RELEASE_TAG":"$API_FILE_PATH" | base64 -w0)
+            # Write the base64 content to a file rather than passing it inline, to avoid
+            # "Argument list too long" errors for large API files (exceeding ARG_MAX).
+            git cat-file blob "$RELEASE_TAG":"$API_FILE_PATH" | base64 -w0 > api-file-release-content.txt
             API_FILE_POST_RELEASE_CONTENT=$(git cat-file blob unsigned/"$GITHUB_REF_NAME":"$API_FILE_PATH" | base64 -w0)
         
             # Commit the API file changes for module
@@ -156,7 +158,7 @@ runs:
               --field branch="$TEMPORARY_BRANCH" \
               --field message="Update public API file for module $MOD for $RELEASE_TAG" \
               --field sha="$API_FILE_INITIAL_SHA" \
-              --field content="$API_FILE_RELEASE_CONTENT" --jq '.commit.sha'
+              --field content=@api-file-release-content.txt --jq '.commit.sha'
           done
         fi
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Push Release Commit
         id: push-release-commit
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@main
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@ab/health/read-api-file-content-from-file-not-from-variable
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Push Release Commit
         id: push-release-commit
-        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@ab/health/read-api-file-content-from-file-not-from-variable
+        uses: guardian/gha-gradle-library-release-workflow/.github/actions/push-release-commit@main
         with:
           GITHUB_APP_ID: ${{ inputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the `push-release-commit` action so we provide the API definition files to `gh api ... ` as file references instead of raw file content.

### Why

This workflow uses API definition files to determine version bumps. After calculating the version bump, the workflow also commits the updated API file. 

These files can get quite large as a library's API surface grows - [example file from Source](https://github.com/guardian/source-apps/blob/main/android/source/api/source-api.txt). This can cause a "Argument list too long" error when the file contents are provided as inline argument - [see here for an example run](https://github.com/guardian/source-apps/actions/runs/28858368420/job/85591242229#step:2:272).

## How has this change been tested?

Tested using [this branch on Source](https://github.com/guardian/source-apps/pull/407/changes?w=1) to do a [successful release](https://github.com/guardian/source-apps/actions/runs/28884933253).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Successful releases for Source and other libraries using this workflow.

